### PR TITLE
add support for Laravel 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "illuminate/console": "~5.2",
-        "illuminate/support": "~5.2",
+        "illuminate/console": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
+        "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
         "intervention/image": "~2",
-        "symfony/http-foundation": "~2.8|~3.0"
+        "symfony/http-foundation": "~2.8|~3.0|~4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",


### PR DESCRIPTION
Laravel does not follow Semver, so I never should have used `~5.2` to begin with. Now we will explicitly state which versions of the illuminate packages we need.

also add support in for Symfony v4.